### PR TITLE
Added saveTableStatsAsCsv to CLI tool

### DIFF
--- a/QualityAnalysis/Apdex/src/main/java/kg/apc/cmdtools/ApdexTool.java
+++ b/QualityAnalysis/Apdex/src/main/java/kg/apc/cmdtools/ApdexTool.java
@@ -91,6 +91,10 @@ public class ApdexTool extends AbstractCMDTool {
 			// Save Apdex results in an HTML file for import in DevOps tool later on
 			String htmlFilename = ApdexLogic.saveTableStatsAsHtml(sInFile, sApdexAQL);
 			System.out.println("Results saved in " + htmlFilename);
+
+      // Save Apdex results in an CSV file for import in Power BI tool later on
+			String htmlFilename = ApdexLogic.saveTableStatsAsCsv(sInFile);
+			System.out.println("Results saved in " + htmlFilename);
 		}
 		return iResult;
 	}

--- a/QualityAnalysis/Apdex/src/main/java/kg/apc/cmdtools/ApdexTool.java
+++ b/QualityAnalysis/Apdex/src/main/java/kg/apc/cmdtools/ApdexTool.java
@@ -93,8 +93,8 @@ public class ApdexTool extends AbstractCMDTool {
 			System.out.println("Results saved in " + htmlFilename);
 
       // Save Apdex results in an CSV file for import in Power BI tool later on
-			String htmlFilename = ApdexLogic.saveTableStatsAsCsv(sInFile);
-			System.out.println("Results saved in " + htmlFilename);
+			String csvFilename = ApdexLogic.saveTableStatsAsCsv(sInFile);
+			System.out.println("Results saved in " + csvFilename);
 		}
 		return iResult;
 	}


### PR DESCRIPTION
Added the saveTableStatsAsCsv to the CLI ApdexTool as in my case I require exactly what you created in the GUI feature, but in the CLI feature to import the CSV to Power BI.

If this is not a desired or good change, could I request that a CLI parameter be added where we could choose to export to HTML or CSV?